### PR TITLE
Change `find_by` to `find`

### DIFF
--- a/app/controllers/stellar_lookout/api/v1/operations_controller.rb
+++ b/app/controllers/stellar_lookout/api/v1/operations_controller.rb
@@ -4,7 +4,7 @@ module StellarLookout
       class OperationsController < BaseController
 
         def create
-          ward = Ward.find_by!(params[:ward_id])
+          ward = Ward.find(params[:ward_id])
           correct_signature = CheckSignature.({
             ward: ward,
             headers: request.headers,


### PR DESCRIPTION
Strange that `find_by` passed locally, and it produced the right SQL, but when run in the Rails app, it generated invalid SQL (i.e. `WHERE (9)`)